### PR TITLE
[CPU] Fix issue: No module named 'fbgemm_gpu.experimental' (#2591)

### DIFF
--- a/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py
@@ -24,7 +24,10 @@ __all__ = [
 aten = torch.ops.aten
 
 
-if importlib.util.find_spec("fbgemm_gpu") is None:
+if (
+    importlib.util.find_spec("fbgemm_gpu") is None
+    or importlib.util.find_spec("fbgemm_gpu.experimental") is None
+):
     quantize_int4_preshuffle = None
     quantize_fp8_row = None
 else:


### PR DESCRIPTION
Fix the following issue
```
  File "/opt/conda/envs/pytorch/lib/python3.10/site-packages/transformers/modeling_utils.py", line 50, in <module>
    from torchao.quantization import Int4WeightOnlyConfig
  File "/opt/conda/envs/pytorch/lib/python3.10/site-packages/torchao-0.13.0+git38de0e9-py3.10.egg/torchao/__init__.py", line 43, in <module>
    from torchao.quantization import (
  File "/opt/conda/envs/pytorch/lib/python3.10/site-packages/torchao-0.13.0+git38de0e9-py3.10.egg/torchao/quantization/__init__.py", line 44, in <module>
    from .quant_api import (
  File "/opt/conda/envs/pytorch/lib/python3.10/site-packages/torchao-0.13.0+git38de0e9-py3.10.egg/torchao/quantization/quant_api.py", line 70, in <module>
    from torchao.quantization.quantize_.workflows import (
  File "/opt/conda/envs/pytorch/lib/python3.10/site-packages/torchao-0.13.0+git38de0e9-py3.10.egg/torchao/quantization/quantize_/workflows/__init__.py", line 1, in <module>
    from .int4.int4_preshuffled_tensor import (
  File "/opt/conda/envs/pytorch/lib/python3.10/site-packages/torchao-0.13.0+git38de0e9-py3.10.egg/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py", line 31, in <module>
    from fbgemm_gpu.experimental.gen_ai.quantize import (
ModuleNotFoundError: No module named 'fbgemm_gpu.experimental'
```

We want to use torchrec on CPU. On CPU, torchrec dependent on the CPU version of fbgemm_gpu. On CPU, fbgemm_gpu not include fbgemm_gpu.experimental.
```
>>> import fbgemm_gpu
>>> fbgemm_gpu.experimental
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'fbgemm_gpu' has no attribute 'experimental'
```

env: `pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/cpu`
Reproduce: `from torchao.quantization import Int4WeightOnlyConfig`
Pull Request resolved: https://github.com/pytorch/ao/pull/2591
Approved by: https://github.com/Xia-Weiwen